### PR TITLE
add index and property accessors

### DIFF
--- a/src/lang/interpreter.rs
+++ b/src/lang/interpreter.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::lang::parser::{LogicalOperator, MathematicalOperator};
+use crate::lang::parser::{Accessor, LogicalOperator, MathematicalOperator};
 
 use super::parser::{
     ComparisonOperator, Expression, Operator, Statement, StatementExpression, Value,
@@ -120,6 +120,23 @@ fn parse_expression(expression: Expression, symbols: &mut HashMap<String, Value>
             }
 
             return Value::Collection(values);
+        }
+        Expression::Accessor(item, accessor) => {
+            let item = parse_expression(*item, symbols);
+            let accessor = match accessor {
+                Accessor::Index(expression) => parse_expression(*expression, symbols),
+                Accessor::Property(_) => panic!("property accessors are not yet implemented"),
+            };
+
+            if let Value::Collection(collection) = &item {
+                if let Value::Number(index) = accessor {
+                    if let Some(val) = collection.get(index as usize) {
+                        return Value::to_owned(val);
+                    }
+                }
+            }
+
+            panic!("could not access item {item} with accessor {accessor}");
         }
         _ => println!("couldn't parse expression"),
     }
@@ -272,6 +289,8 @@ fn check_builtin_functions(
 
 #[cfg(test)]
 mod tests {
+    use crate::lang::parser::Accessor;
+
     use super::*;
 
     #[test]
@@ -1424,5 +1443,87 @@ mod tests {
         ]);
         parse_statement(statement, &mut symbols);
         assert_eq!(symbols.get("x").unwrap(), &Value::Number(15.0));
+    }
+
+    #[test]
+    fn test_parse_index_accessor() {
+        let mut symbols = HashMap::new();
+        symbols.insert(
+            "x".into(),
+            Value::Collection(vec![
+                Value::Number(1.0),
+                Value::Number(2.0),
+                Value::Number(3.0),
+            ]),
+        );
+        let statement = Statement::Reassignment(
+            "x".into(),
+            Box::new(Expression::Accessor(
+                Box::new(Expression::Identifier("x".into())),
+                Accessor::Index(Box::new(Expression::Literal(Value::Number(1.0)))),
+            )),
+        );
+        parse_statement(statement, &mut symbols);
+        assert_eq!(symbols.get("x").unwrap(), &Value::Number(2.0));
+    }
+
+    #[test]
+    fn test_parse_index_accessor_multiple_indices() {
+        let mut symbols = HashMap::new();
+        symbols.insert(
+            "x".into(),
+            Value::Collection(vec![
+                Value::Collection(vec![
+                    Value::Number(1.0),
+                    Value::Number(2.0),
+                    Value::Number(3.0),
+                ]),
+                Value::Collection(vec![
+                    Value::Number(4.0),
+                    Value::Number(5.0),
+                    Value::Number(6.0),
+                ]),
+                Value::Collection(vec![
+                    Value::Number(7.0),
+                    Value::Number(8.0),
+                    Value::Number(9.0),
+                ]),
+            ]),
+        );
+        let statement = Statement::Reassignment(
+            "x".into(),
+            Box::new(Expression::Accessor(
+                Box::new(Expression::Accessor(
+                    Box::new(Expression::Identifier("x".into())),
+                    Accessor::Index(Box::new(Expression::Literal(Value::Number(1.0)))),
+                )),
+                Accessor::Index(Box::new(Expression::Literal(Value::Number(1.0)))),
+            )),
+        );
+        parse_statement(statement, &mut symbols);
+        assert_eq!(symbols.get("x").unwrap(), &Value::Number(5.0),);
+    }
+
+    #[test]
+    #[should_panic(expected = "property accessors are not yet implemented")]
+    fn test_parse_property_accessor() {
+        let mut symbols = HashMap::new();
+        symbols.insert(
+            "x".into(),
+            Value::Collection(vec![
+                Value::Number(1.0),
+                Value::Number(2.0),
+                Value::Number(3.0),
+            ]),
+        );
+        let statement = Statement::Reassignment(
+            "x".into(),
+            Box::new(Expression::Accessor(
+                Box::new(Expression::Identifier("x".into())),
+                Accessor::Property(Value::String("length".into())),
+            )),
+        );
+        parse_statement(statement, &mut symbols);
+        assert_eq!(symbols.get("x").unwrap(), &Value::Number(3.0));
     }
 }

--- a/src/lang/parser.rs
+++ b/src/lang/parser.rs
@@ -68,7 +68,7 @@ pub enum Expression {
     Collection(Vec<Expression>),
     Identifier(String),
     FunctionCall(Box<Expression>, Vec<Expression>),
-    IndexAccess(Box<Expression>),
+    Accessor(Box<Expression>, Accessor),
 }
 
 #[allow(dead_code)]
@@ -83,6 +83,13 @@ pub enum Statement {
     Return(Box<Expression>),
     For(String, Box<Expression>, Box<Statement>),
     Break,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, PartialEq, Clone)]
+pub enum Accessor {
+    Index(Box<Expression>),
+    Property(Value),
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -282,19 +289,65 @@ impl Parser {
                     return self.parse_binary_expression(expression);
                 }
 
-                while self.check(Token::LeftParen) {
-                    expression = self.parse_fn_call(expression);
+                if self.peek().is_accessor_indicator() {
+                    expression = self.parse_possible_accessor(Some(expression));
                 }
 
                 expression
             }
-            Token::LeftBracket => self.parse_collection(),
+            Token::LeftBracket => self.parse_possible_accessor(None),
             _ => panic!("Unexpected token {:?}", self.peek()),
         };
 
         self.check_and_skip(Token::Semicolon);
 
         expression
+    }
+
+    fn parse_possible_accessor(&mut self, initial: Option<Expression>) -> Expression {
+        let mut expression: Expression;
+
+        if let Some(identifier) = initial {
+            expression = identifier;
+
+            while self.can_peek() && self.peek().is_accessor_indicator() {
+                if self.check(Token::LeftParen) {
+                    expression = self.parse_fn_call(expression);
+                    continue;
+                }
+
+                if self.check(Token::LeftBracket) {
+                    expression = self.parse_index_accessor(expression);
+                    continue;
+                }
+
+                expression = self.parse_property_accessor(expression);
+            }
+
+            return expression;
+        }
+
+        self.parse_collection()
+    }
+
+    fn parse_index_accessor(&mut self, identifier: Expression) -> Expression {
+        self.expect(Token::LeftBracket);
+        let index = self.parse_expression();
+        self.expect(Token::RightBracket);
+        Expression::Accessor(Box::new(identifier), Accessor::Index(Box::new(index)))
+    }
+
+    fn parse_property_accessor(&mut self, identifier: Expression) -> Expression {
+        self.expect(Token::Dot);
+        let property = self.next();
+        if let Token::Identifier(property_identifier) = property {
+            return Expression::Accessor(
+                Box::new(identifier),
+                Accessor::Property(Value::String(property_identifier)),
+            );
+        }
+
+        panic!("unexpected property accessor {:#?}", property);
     }
 
     fn parse_binary_expression(&mut self, initial: Expression) -> Expression {
@@ -1374,6 +1427,92 @@ mod tests {
                     ])))
                 ))
             ]))))
+        );
+    }
+
+    #[test]
+    fn test_accessor_index() {
+        let tokens = vec![
+            Token::Identifier("x".into()),
+            Token::LeftBracket,
+            Token::Number("1".into()),
+            Token::RightBracket,
+        ];
+        let mut parser = Parser::new(tokens);
+        let node = parser.parse();
+        assert_eq!(
+            node,
+            StatementExpression::Expression(Expression::Accessor(
+                Box::new(Expression::Identifier("x".into())),
+                Accessor::Index(Box::new(Expression::Literal(Value::Number(1.0)))),
+            ))
+        );
+    }
+
+    #[test]
+    fn test_accessor_index_multiple_indices() {
+        let tokens = vec![
+            Token::Identifier("x".into()),
+            Token::LeftBracket,
+            Token::Number("1".into()),
+            Token::RightBracket,
+            Token::LeftBracket,
+            Token::Number("2".into()),
+            Token::RightBracket,
+        ];
+        let mut parser = Parser::new(tokens);
+        let node = parser.parse();
+
+        assert_eq!(
+            node,
+            StatementExpression::Expression(Expression::Accessor(
+                Box::new(Expression::Accessor(
+                    Box::new(Expression::Identifier("x".into())),
+                    Accessor::Index(Box::new(Expression::Literal(Value::Number(1.0)))),
+                )),
+                Accessor::Index(Box::new(Expression::Literal(Value::Number(2.0)))),
+            ))
+        );
+    }
+
+    #[test]
+    fn test_accessor_property() {
+        let tokens = vec![
+            Token::Identifier("x".into()),
+            Token::Dot,
+            Token::Identifier("y".into()),
+        ];
+        let mut parser = Parser::new(tokens);
+        let node = parser.parse();
+        assert_eq!(
+            node,
+            StatementExpression::Expression(Expression::Accessor(
+                Box::new(Expression::Identifier("x".into())),
+                Accessor::Property(Value::String("y".into()))
+            ),)
+        );
+    }
+
+    #[test]
+    fn test_accessor_property_multiple_properties() {
+        let tokens = vec![
+            Token::Identifier("x".into()),
+            Token::Dot,
+            Token::Identifier("y".into()),
+            Token::Dot,
+            Token::Identifier("z".into()),
+        ];
+        let mut parser = Parser::new(tokens);
+        let node = parser.parse();
+        assert_eq!(
+            node,
+            StatementExpression::Expression(Expression::Accessor(
+                Box::new(Expression::Accessor(
+                    Box::new(Expression::Identifier("x".into())),
+                    Accessor::Property(Value::String("y".into())),
+                )),
+                Accessor::Property(Value::String("z".into())),
+            ))
         );
     }
 }

--- a/src/lang/token.rs
+++ b/src/lang/token.rs
@@ -123,6 +123,13 @@ impl Token {
     pub fn is_operator(&self) -> bool {
         self.is_logical() || self.is_comparator() || self.is_mathematical()
     }
+
+    pub fn is_accessor_indicator(&self) -> bool {
+        match self {
+            Token::LeftParen | Token::Dot | Token::LeftBracket => true,
+            _ => false,
+        }
+    }
 }
 
 // tests for the token module
@@ -207,5 +214,13 @@ mod tests {
         assert!(Token::And.is_operator());
         assert!(Token::Or.is_operator());
         assert!(!Token::LeftBrace.is_operator());
+    }
+
+    #[test]
+    fn test_is_accessor_indicator() {
+        assert!(Token::LeftParen.is_accessor_indicator());
+        assert!(Token::Dot.is_accessor_indicator());
+        assert!(Token::LeftBracket.is_accessor_indicator());
+        assert!(!Token::Plus.is_accessor_indicator());
     }
 }


### PR DESCRIPTION
this pr allows accessors to complex types like maps and collections. note that maps are not yet implemented in brain, so property accessors do not work yet in the interpreter, but their implementation should be minimal work

```
let collections = [
    [1, 2, 3],
    [4, 5, 6],
    [7, 8, 9]
];

print("collections[0][0]: ", collections[0][0]);
```

now works and prints
`collections[0][0]: 1`

this also builds on #9 and allows things like

```
fn adder(x, y) {
  return x + y;
}

let collection = [adder];

print(adder[0](1, 2));
```