### PR TITLE
improvements to devex of streams & tokens

### DIFF
--- a/brain-grammar/src/grammar/expressions/accessors/field.rs
+++ b/brain-grammar/src/grammar/expressions/accessors/field.rs
@@ -24,28 +24,10 @@ impl Field {
         target: Expression,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         stream.expect(BrainToken::Dot)?;
-        let next = stream.next();
 
-        if next.is_none() {
-            return Err(Error::new(
-                ErrorKind::UnexpectedEndOfFile,
-                "Expected identifier, found End of File".to_string(),
-            ));
-        }
+        let token = stream.expect(BrainToken::Identifier)?;
 
-        let token = &next.unwrap();
-
-        if let BrainToken::Identifier = token.token {
-            return Ok(Self::new(token.data.clone().unwrap(), target));
-        }
-
-        Err(Error::new(
-            ErrorKind::UnexpectedToken,
-            format!(
-                "Expected identifier, found {} ({} - {})",
-                token.token, token.span.start, token.span.end
-            ),
-        ))
+        Ok(Self::new(token.data.clone(), target))
     }
 }
 
@@ -173,8 +155,8 @@ mod tests {
         let expression = Expression::new_map(vec![]);
 
         let tokens = vec![
-            Token::new(0..1, BrainToken::Dot, None),
-            Token::new(1..2, BrainToken::Identifier, Some("a".to_string())),
+            Token::new(0..1, BrainToken::Dot, ".".to_string()),
+            Token::new(1..2, BrainToken::Identifier, "a".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -189,7 +171,7 @@ mod tests {
     fn parse_field_accessor_eof() {
         let expression = Expression::new_map(vec![]);
 
-        let tokens = vec![Token::new(0..1, BrainToken::Dot, None)];
+        let tokens = vec![Token::new(0..1, BrainToken::Dot, ".".to_string())];
 
         let stream = &mut TokenStream::from_vec(tokens);
 
@@ -198,7 +180,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.err().unwrap().to_string(),
-            "[UnexpectedEndOfFile]: Expected identifier, found End of File".to_string()
+            "[UnexpectedEndOfFile]: Expected Identifier, but found End of File".to_string()
         )
     }
 
@@ -207,8 +189,8 @@ mod tests {
         let expression = Expression::new_map(vec![]);
 
         let tokens = vec![
-            Token::new(0..1, BrainToken::Dot, None),
-            Token::new(1..2, BrainToken::Null, None),
+            Token::new(0..1, BrainToken::Dot, ".".to_string()),
+            Token::new(1..2, BrainToken::Null, "null".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -218,7 +200,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.err().unwrap().to_string(),
-            "[UnexpectedToken]: Expected identifier, found Token::Null (1 - 2)".to_string()
+            "[UnexpectedToken]: Expected Identifier, found Null (1 - 2)".to_string()
         )
     }
 }

--- a/brain-grammar/src/grammar/expressions/accessors/index.rs
+++ b/brain-grammar/src/grammar/expressions/accessors/index.rs
@@ -395,9 +395,9 @@ mod tests {
         let expression = Expression::new_identifier("a".to_string());
 
         let tokens = vec![
-            Token::new(0..1, BrainToken::LeftBracket, None),
-            Token::new(1..2, BrainToken::Number, Some("0".to_string())),
-            Token::new(2..3, BrainToken::RightBracket, None),
+            Token::new(0..1, BrainToken::LeftBracket, "[".to_string()),
+            Token::new(1..2, BrainToken::Number, "0".to_string()),
+            Token::new(2..3, BrainToken::RightBracket, "]".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);

--- a/brain-grammar/src/grammar/expressions/accessors/mod.rs
+++ b/brain-grammar/src/grammar/expressions/accessors/mod.rs
@@ -134,9 +134,9 @@ mod tests {
     #[test]
     fn parse_accessor_is_collection() {
         let tokens = vec![
-            Token::new(0..1, BrainToken::LeftBracket, None),
-            Token::new(1..2, BrainToken::Number, Some("0".to_string())),
-            Token::new(2..3, BrainToken::RightBracket, None),
+            Token::new(0..1, BrainToken::LeftBracket, "[".to_string()),
+            Token::new(1..2, BrainToken::Number, "0".to_string()),
+            Token::new(2..3, BrainToken::RightBracket, "]".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -156,9 +156,9 @@ mod tests {
             Expression::new_collection(vec![Expression::new_literal(Value::Number(0))]);
 
         let tokens = vec![
-            Token::new(7..8, BrainToken::LeftBracket, None),
-            Token::new(8..9, BrainToken::Number, Some("0".to_string())),
-            Token::new(9..10, BrainToken::RightBracket, None),
+            Token::new(7..8, BrainToken::LeftBracket, "[".to_string()),
+            Token::new(8..9, BrainToken::Number, "0".to_string()),
+            Token::new(9..10, BrainToken::RightBracket, "]".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -181,11 +181,11 @@ mod tests {
             Expression::new_collection(vec![Expression::new_literal(Value::Number(0))]);
 
         let tokens = vec![
-            Token::new(7..8, BrainToken::LeftBracket, None),
-            Token::new(8..11, BrainToken::Identifier, Some("func".to_string())),
-            Token::new(11..12, BrainToken::LeftParen, None),
-            Token::new(12..13, BrainToken::RightParen, None),
-            Token::new(9..10, BrainToken::RightBracket, None),
+            Token::new(7..8, BrainToken::LeftBracket, "[".to_string()),
+            Token::new(8..11, BrainToken::Identifier, "func".to_string()),
+            Token::new(11..12, BrainToken::LeftParen, "(".to_string()),
+            Token::new(12..13, BrainToken::RightParen, ")".to_string()),
+            Token::new(9..10, BrainToken::RightBracket, "]".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -210,8 +210,8 @@ mod tests {
         let expression = Expression::new_map(vec![]);
 
         let tokens = vec![
-            Token::new(7..8, BrainToken::Dot, None),
-            Token::new(8..9, BrainToken::Identifier, Some("a".to_string())),
+            Token::new(7..8, BrainToken::Dot, ".".to_string()),
+            Token::new(8..9, BrainToken::Identifier, "a".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -229,7 +229,7 @@ mod tests {
     fn parse_accessor_is_not_accessor() {
         let expression = Expression::new_map(vec![]);
 
-        let tokens = vec![Token::new(0..1, BrainToken::Semicolon, None)];
+        let tokens = vec![Token::new(0..1, BrainToken::Semicolon, ";".to_string())];
 
         let stream = &mut TokenStream::from_vec(tokens);
 

--- a/brain-grammar/src/grammar/expressions/binary.rs
+++ b/brain-grammar/src/grammar/expressions/binary.rs
@@ -85,9 +85,9 @@ mod test {
     #[test]
     fn parse_binary() {
         let tokens = vec![
-            Token::new(0..1, BrainToken::Number, Some("0".to_string())),
-            Token::new(0..1, BrainToken::LessThan, None),
-            Token::new(0..1, BrainToken::Number, Some("1".to_string())),
+            Token::new(0..1, BrainToken::Number, "0".to_string()),
+            Token::new(0..1, BrainToken::LessThan, "<".to_string()),
+            Token::new(0..1, BrainToken::Number, "1".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -110,8 +110,8 @@ mod test {
         let expression = Expression::new_literal(Value::Number(0));
 
         let tokens = vec![
-            Token::new(0..1, BrainToken::LessThan, None),
-            Token::new(0..1, BrainToken::Number, Some("1".to_string())),
+            Token::new(0..1, BrainToken::LessThan, "<".to_string()),
+            Token::new(0..1, BrainToken::Number, "1".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);

--- a/brain-grammar/src/grammar/expressions/collection.rs
+++ b/brain-grammar/src/grammar/expressions/collection.rs
@@ -94,9 +94,9 @@ mod tests {
     #[test]
     fn parse_collection() {
         let tokens = vec![
-            Token::new(0..1, BrainToken::LeftBracket, None),
-            Token::new(1..2, BrainToken::Number, Some("0".to_string())),
-            Token::new(2..3, BrainToken::RightBracket, None),
+            Token::new(0..1, BrainToken::LeftBracket, "[".to_string()),
+            Token::new(1..2, BrainToken::Number, "0".to_string()),
+            Token::new(2..3, BrainToken::RightBracket, "]".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);

--- a/brain-grammar/src/grammar/expressions/functioncall.rs
+++ b/brain-grammar/src/grammar/expressions/functioncall.rs
@@ -37,16 +37,7 @@ impl FunctionCall {
         while !stream.check(BrainToken::RightParen) {
             let expression = Expression::parse(stream)?;
 
-            let next = stream.peek();
-
-            if next.is_none() {
-                return Err(
-                    Error::new(
-                        ErrorKind::UnexpectedEndOfFile,
-                        "Expected binary expression, function call, or ending parenthesis, found End of File".to_string()
-                    )
-                );
-            }
+            stream.assert_peek("Expected binary expression, function call, or ending parenthesis, found End of File".to_string())?;
 
             stream.skip_if(BrainToken::Comma);
 
@@ -230,9 +221,9 @@ mod tests {
     #[test]
     fn parse_function_call() {
         let tokens = vec![
-            Token::new(0..3, BrainToken::Identifier, Some("foo".to_string())),
-            Token::new(4..5, BrainToken::LeftParen, None),
-            Token::new(5..6, BrainToken::RightParen, None),
+            Token::new(0..3, BrainToken::Identifier, "foo".to_string()),
+            Token::new(4..5, BrainToken::LeftParen, "(".to_string()),
+            Token::new(5..6, BrainToken::RightParen, ")".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -251,8 +242,8 @@ mod tests {
         let initial = Expression::new_identifier("foo".to_string());
 
         let tokens = vec![
-            Token::new(0..1, BrainToken::LeftParen, None),
-            Token::new(1..2, BrainToken::RightParen, None),
+            Token::new(0..1, BrainToken::LeftParen, "(".to_string()),
+            Token::new(1..2, BrainToken::RightParen, ")".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -269,12 +260,12 @@ mod tests {
     #[test]
     fn parse_function_call_with_args() {
         let tokens = vec![
-            Token::new(0..3, BrainToken::Identifier, Some("foo".to_string())),
-            Token::new(4..5, BrainToken::LeftParen, None),
-            Token::new(5..6, BrainToken::Identifier, Some("a".to_string())),
-            Token::new(7..8, BrainToken::Comma, None),
-            Token::new(9..10, BrainToken::Identifier, Some("b".to_string())),
-            Token::new(11..12, BrainToken::RightParen, None),
+            Token::new(0..3, BrainToken::Identifier, "foo".to_string()),
+            Token::new(4..5, BrainToken::LeftParen, "(".to_string()),
+            Token::new(5..6, BrainToken::Identifier, "a".to_string()),
+            Token::new(7..8, BrainToken::Comma, ",".to_string()),
+            Token::new(9..10, BrainToken::Identifier, "b".to_string()),
+            Token::new(11..12, BrainToken::RightParen, ")".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -297,14 +288,14 @@ mod tests {
     #[test]
     fn parse_function_call_with_function_arg() {
         let tokens = vec![
-            Token::new(0..3, BrainToken::Identifier, Some("foo".to_string())),
-            Token::new(4..5, BrainToken::LeftParen, None),
-            Token::new(5..6, BrainToken::Identifier, Some("a".to_string())),
-            Token::new(7..8, BrainToken::Comma, None),
-            Token::new(9..10, BrainToken::Identifier, Some("b".to_string())),
-            Token::new(10..11, BrainToken::LeftParen, None),
-            Token::new(11..12, BrainToken::RightParen, None),
-            Token::new(13..14, BrainToken::RightParen, None),
+            Token::new(0..3, BrainToken::Identifier, "foo".to_string()),
+            Token::new(4..5, BrainToken::LeftParen, "(".to_string()),
+            Token::new(5..6, BrainToken::Identifier, "a".to_string()),
+            Token::new(7..8, BrainToken::Comma, ",".to_string()),
+            Token::new(9..10, BrainToken::Identifier, "b".to_string()),
+            Token::new(10..11, BrainToken::LeftParen, "(".to_string()),
+            Token::new(11..12, BrainToken::RightParen, ")".to_string()),
+            Token::new(13..14, BrainToken::RightParen, ")".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -330,14 +321,14 @@ mod tests {
     #[test]
     fn parse_function_call_with_binary_arg() {
         let tokens = vec![
-            Token::new(0..3, BrainToken::Identifier, Some("foo".to_string())),
-            Token::new(4..5, BrainToken::LeftParen, None),
-            Token::new(5..6, BrainToken::Identifier, Some("a".to_string())),
-            Token::new(7..8, BrainToken::Comma, None),
-            Token::new(9..10, BrainToken::Number, Some("0".to_string())),
-            Token::new(10..11, BrainToken::Plus, None),
-            Token::new(9..10, BrainToken::Number, Some("1".to_string())),
-            Token::new(14..15, BrainToken::RightParen, None),
+            Token::new(0..3, BrainToken::Identifier, "foo".to_string()),
+            Token::new(4..5, BrainToken::LeftParen, "(".to_string()),
+            Token::new(5..6, BrainToken::Identifier, "a".to_string()),
+            Token::new(7..8, BrainToken::Comma, ",".to_string()),
+            Token::new(9..10, BrainToken::Number, "0".to_string()),
+            Token::new(10..11, BrainToken::Plus, "+".to_string()),
+            Token::new(9..10, BrainToken::Number, "1".to_string()),
+            Token::new(14..15, BrainToken::RightParen, ")".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -364,9 +355,9 @@ mod tests {
     #[test]
     fn parse_function_call_eof() {
         let tokens = vec![
-            Token::new(0..3, BrainToken::Identifier, Some("foo".to_string())),
-            Token::new(4..5, BrainToken::LeftParen, None),
-            Token::new(5..6, BrainToken::Identifier, Some("a".to_string())),
+            Token::new(0..3, BrainToken::Identifier, "foo".to_string()),
+            Token::new(4..5, BrainToken::LeftParen, "(".to_string()),
+            Token::new(5..6, BrainToken::Identifier, "a".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);

--- a/brain-grammar/src/grammar/expressions/identifier.rs
+++ b/brain-grammar/src/grammar/expressions/identifier.rs
@@ -29,28 +29,9 @@ impl Evaluate for Identifier {
 
 impl Parse for Identifier {
     fn parse(stream: &mut TokenStream<BrainToken>) -> Result<Self, Box<dyn std::error::Error>> {
-        let next = stream.next();
+        let next = stream.expect(BrainToken::Identifier)?;
 
-        if next.is_none() {
-            return Err(Error::new(
-                ErrorKind::UnexpectedEndOfFile,
-                format!("Expected identifier, found End of File"),
-            ));
-        }
-
-        let token = next.unwrap();
-
-        if let BrainToken::Identifier = &token.token {
-            return Ok(Identifier::new(token.data.clone().unwrap()));
-        }
-
-        return Err(Error::new(
-            ErrorKind::UnexpectedExpression,
-            format!(
-                "Expected identifier, found {} ({} - {})",
-                token.token, token.span.start, token.span.end
-            ),
-        ));
+        return Ok(Identifier::new(next.data.clone()));
     }
 }
 
@@ -93,11 +74,7 @@ mod tests {
 
     #[test]
     fn parse_identifier() {
-        let tokens = vec![Token::new(
-            0..1,
-            BrainToken::Identifier,
-            Some("a".to_string()),
-        )];
+        let tokens = vec![Token::new(0..1, BrainToken::Identifier, "a".to_string())];
 
         let stream = &mut TokenStream::from_vec(tokens);
 
@@ -118,13 +95,13 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.err().unwrap().to_string(),
-            "[UnexpectedEndOfFile]: Expected identifier, found End of File".to_string()
+            "[UnexpectedEndOfFile]: Expected Identifier, but found End of File".to_string()
         );
     }
 
     #[test]
     fn parse_identifier_not_identifier() {
-        let tokens = vec![Token::new(0..3, BrainToken::Null, None)];
+        let tokens = vec![Token::new(0..3, BrainToken::Null, "null".to_string())];
 
         let stream = &mut TokenStream::from_vec(tokens);
 
@@ -133,7 +110,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.err().unwrap().to_string(),
-            "[UnexpectedExpression]: Expected identifier, found Token::Null (0 - 3)".to_string()
+            "[UnexpectedToken]: Expected Identifier, found Null (0 - 3)".to_string()
         );
     }
 }

--- a/brain-grammar/src/grammar/expressions/map.rs
+++ b/brain-grammar/src/grammar/expressions/map.rs
@@ -211,11 +211,11 @@ mod tests {
     #[test]
     fn parse_map() {
         let tokens = vec![
-            Token::new(0..1, BrainToken::LeftBrace, None),
-            Token::new(0..1, BrainToken::Identifier, Some("a".to_string())),
-            Token::new(0..1, BrainToken::Colon, None),
-            Token::new(0..1, BrainToken::Number, Some("0".to_string())),
-            Token::new(0..1, BrainToken::RightBrace, None),
+            Token::new(0..1, BrainToken::LeftBrace, "{".to_string()),
+            Token::new(0..1, BrainToken::Identifier, "a".to_string()),
+            Token::new(0..1, BrainToken::Colon, ":".to_string()),
+            Token::new(0..1, BrainToken::Number, "0".to_string()),
+            Token::new(0..1, BrainToken::RightBrace, "}".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -235,13 +235,13 @@ mod tests {
     #[test]
     fn parse_map_invalid_key_collection() {
         let tokens = vec![
-            Token::new(0..1, BrainToken::LeftBrace, None),
-            Token::new(0..1, BrainToken::LeftBracket, None),
-            Token::new(0..1, BrainToken::Identifier, Some("a".to_string())),
-            Token::new(0..1, BrainToken::RightBracket, None),
-            Token::new(0..1, BrainToken::Colon, None),
-            Token::new(0..1, BrainToken::Number, Some("0".to_string())),
-            Token::new(0..1, BrainToken::RightBrace, None),
+            Token::new(0..1, BrainToken::LeftBrace, "{".to_string()),
+            Token::new(0..1, BrainToken::LeftBracket, "[".to_string()),
+            Token::new(0..1, BrainToken::Identifier, "a".to_string()),
+            Token::new(0..1, BrainToken::RightBracket, "]".to_string()),
+            Token::new(0..1, BrainToken::Colon, ":".to_string()),
+            Token::new(0..1, BrainToken::Number, "0".to_string()),
+            Token::new(0..1, BrainToken::RightBrace, "}".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -258,12 +258,12 @@ mod tests {
     #[test]
     fn parse_map_invalid_key_map() {
         let tokens = vec![
-            Token::new(0..1, BrainToken::LeftBrace, None),
-            Token::new(0..1, BrainToken::LeftBrace, None),
-            Token::new(0..1, BrainToken::RightBrace, None),
-            Token::new(0..1, BrainToken::Colon, None),
-            Token::new(0..1, BrainToken::Number, Some("0".to_string())),
-            Token::new(0..1, BrainToken::RightBrace, None),
+            Token::new(0..1, BrainToken::LeftBrace, "{".to_string()),
+            Token::new(0..1, BrainToken::LeftBrace, "{".to_string()),
+            Token::new(0..1, BrainToken::RightBrace, "}".to_string()),
+            Token::new(0..1, BrainToken::Colon, ":".to_string()),
+            Token::new(0..1, BrainToken::Number, "0".to_string()),
+            Token::new(0..1, BrainToken::RightBrace, "}".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -280,14 +280,14 @@ mod tests {
     #[test]
     fn parse_map_invalid_key_function() {
         let tokens = vec![
-            Token::new(0..1, BrainToken::LeftBrace, None),
-            Token::new(0..1, BrainToken::Identifier, Some("test".to_string())),
-            Token::new(0..1, BrainToken::LeftParen, None),
-            Token::new(0..1, BrainToken::RightParen, None),
-            Token::new(0..1, BrainToken::RightBrace, None),
-            Token::new(0..1, BrainToken::Colon, None),
-            Token::new(0..1, BrainToken::Number, Some("0".to_string())),
-            Token::new(0..1, BrainToken::RightBrace, None),
+            Token::new(0..1, BrainToken::LeftBrace, "{".to_string()),
+            Token::new(0..1, BrainToken::Identifier, "test".to_string()),
+            Token::new(0..1, BrainToken::LeftParen, "(".to_string()),
+            Token::new(0..1, BrainToken::RightParen, ")".to_string()),
+            Token::new(0..1, BrainToken::RightBrace, "}".to_string()),
+            Token::new(0..1, BrainToken::Colon, ":".to_string()),
+            Token::new(0..1, BrainToken::Number, "0".to_string()),
+            Token::new(0..1, BrainToken::RightBrace, "}".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);

--- a/brain-grammar/src/grammar/expressions/operator/mod.rs
+++ b/brain-grammar/src/grammar/expressions/operator/mod.rs
@@ -98,39 +98,31 @@ impl Operator {
 
 impl Parse for Operator {
     fn parse(stream: &mut TokenStream<BrainToken>) -> Result<Self, Box<dyn std::error::Error>> {
-        let next = stream.next();
+        let next = stream.assert_next("Expected operator, found End of File".to_string())?;
 
-        if next.is_none() {
-            return Err(Error::new(
-                ErrorKind::UnexpectedEndOfFile,
-                "Expected operator, found End of File".to_string(),
-            ));
+        let token = &next.token;
+
+        if Mathematical::matches(token) {
+            return Ok(Operator::Mathematical(Mathematical::parse(token)));
         }
 
-        let token = &next.unwrap();
-        let token_literal = &token.token;
-
-        if Mathematical::matches(token_literal) {
-            return Ok(Operator::Mathematical(Mathematical::parse(token_literal)));
+        if Logical::matches(token) {
+            return Ok(Operator::Logical(Logical::parse(token)));
         }
 
-        if Logical::matches(token_literal) {
-            return Ok(Operator::Logical(Logical::parse(token_literal)));
+        if Comparison::matches(token) {
+            return Ok(Operator::Comparison(Comparison::parse(token)));
         }
 
-        if Comparison::matches(token_literal) {
-            return Ok(Operator::Comparison(Comparison::parse(token_literal)));
-        }
-
-        if Bitwise::matches(token_literal) {
-            return Ok(Operator::Bitwise(Bitwise::parse(token_literal)));
+        if Bitwise::matches(token) {
+            return Ok(Operator::Bitwise(Bitwise::parse(token)));
         }
 
         return Err(Error::new(
             ErrorKind::UnexpectedToken,
             format!(
-                "Expected operator, found {token_literal} ({} - {})",
-                token.span.start, token.span.end
+                "Expected operator, found {token} ({} - {})",
+                &next.span.start, &next.span.end
             ),
         ));
     }
@@ -289,7 +281,7 @@ mod tests {
 
     #[test]
     fn parse_operator_mathematical() {
-        let tokens = vec![Token::new(0..1, BrainToken::Plus, None)];
+        let tokens = vec![Token::new(0..1, BrainToken::Plus, "+".to_string())];
 
         let stream = &mut TokenStream::from_vec(tokens);
 
@@ -301,7 +293,7 @@ mod tests {
 
     #[test]
     fn parse_operator_logical() {
-        let tokens = vec![Token::new(0..2, BrainToken::And, None)];
+        let tokens = vec![Token::new(0..2, BrainToken::And, "and".to_string())];
 
         let stream = &mut TokenStream::from_vec(tokens);
 
@@ -313,7 +305,7 @@ mod tests {
 
     #[test]
     fn parse_operator_comparison() {
-        let tokens = vec![Token::new(0..1, BrainToken::GreaterThan, None)];
+        let tokens = vec![Token::new(0..1, BrainToken::GreaterThan, ">".to_string())];
 
         let stream = &mut TokenStream::from_vec(tokens);
 
@@ -325,7 +317,7 @@ mod tests {
 
     #[test]
     fn parse_operator_bitwise_and() {
-        let tokens = vec![Token::new(0..1, BrainToken::BitwiseAnd, None)];
+        let tokens = vec![Token::new(0..1, BrainToken::BitwiseAnd, "&".to_string())];
 
         let stream = &mut TokenStream::from_vec(tokens);
 
@@ -337,7 +329,7 @@ mod tests {
 
     #[test]
     fn parse_operator_bitwise_or() {
-        let tokens = vec![Token::new(0..1, BrainToken::BitwiseOr, None)];
+        let tokens = vec![Token::new(0..1, BrainToken::BitwiseOr, "|".to_string())];
 
         let stream = &mut TokenStream::from_vec(tokens);
 
@@ -364,7 +356,7 @@ mod tests {
 
     #[test]
     fn parse_operator_not_operator() {
-        let tokens = vec![Token::new(0..1, BrainToken::LeftBrace, None)];
+        let tokens = vec![Token::new(0..1, BrainToken::LeftBrace, "{".to_string())];
 
         let stream = &mut TokenStream::from_vec(tokens);
 

--- a/brain-grammar/src/grammar/mod.rs
+++ b/brain-grammar/src/grammar/mod.rs
@@ -142,7 +142,7 @@ mod tests {
 
     #[test]
     fn parse_node_statement() {
-        let tokens = vec![Token::new(0..4, BrainToken::Break, None)];
+        let tokens = vec![Token::new(0..4, BrainToken::Break, "break".to_string())];
 
         let stream = &mut TokenStream::from_vec(tokens);
 
@@ -154,11 +154,7 @@ mod tests {
 
     #[test]
     fn parse_node_expression() {
-        let tokens = vec![Token::new(
-            0..1,
-            BrainToken::String,
-            Some(r#""a""#.to_string()),
-        )];
+        let tokens = vec![Token::new(0..1, BrainToken::String, r#""a""#.to_string())];
 
         let stream = &mut TokenStream::from_vec(tokens);
 

--- a/brain-grammar/src/grammar/statements/assignment.rs
+++ b/brain-grammar/src/grammar/statements/assignment.rs
@@ -42,16 +42,7 @@ impl Parse for Assignment {
     fn parse(stream: &mut TokenStream<BrainToken>) -> Result<Self, Box<dyn std::error::Error>> {
         stream.expect(BrainToken::Let)?;
 
-        let next = stream.next();
-
-        if next.is_none() {
-            return Err(Error::new(
-                ErrorKind::UnexpectedEndOfFile,
-                "Expected identifier, found End of File".to_string(),
-            ));
-        }
-
-        let token = next.unwrap().clone();
+        let identifier = stream.expect(BrainToken::Identifier)?.clone();
 
         stream.expect(BrainToken::Assign)?;
 
@@ -59,7 +50,7 @@ impl Parse for Assignment {
 
         stream.skip_if(BrainToken::Semicolon);
 
-        let assignment = Self::new(token.data.unwrap(), expression);
+        let assignment = Self::new(identifier.data, expression);
 
         Ok(assignment)
     }
@@ -210,10 +201,10 @@ mod tests {
     #[test]
     fn parse_assignment() {
         let tokens = vec![
-            Token::new(0..3, BrainToken::Let, None),
-            Token::new(4..5, BrainToken::Identifier, Some("x".into())),
-            Token::new(6..7, BrainToken::Assign, None),
-            Token::new(8..9, BrainToken::String, Some(r#""hello""#.into())),
+            Token::new(0..3, BrainToken::Let, "let".to_string()),
+            Token::new(4..5, BrainToken::Identifier, "x".into()),
+            Token::new(6..7, BrainToken::Assign, "=".to_string()),
+            Token::new(8..9, BrainToken::String, r#""hello""#.into()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -233,10 +224,10 @@ mod tests {
     #[test]
     fn parse_assignment_number() {
         let tokens = vec![
-            Token::new(0..3, BrainToken::Let, None),
-            Token::new(4..5, BrainToken::Identifier, Some("x".into())),
-            Token::new(6..7, BrainToken::Assign, None),
-            Token::new(8..9, BrainToken::Number, Some("0".into())),
+            Token::new(0..3, BrainToken::Let, "let".to_string()),
+            Token::new(4..5, BrainToken::Identifier, "x".into()),
+            Token::new(6..7, BrainToken::Assign, "=".to_string()),
+            Token::new(8..9, BrainToken::Number, "0".into()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -253,10 +244,10 @@ mod tests {
     #[test]
     fn parse_assignment_null() {
         let tokens = vec![
-            Token::new(0..3, BrainToken::Let, None),
-            Token::new(4..5, BrainToken::Identifier, Some("x".into())),
-            Token::new(6..7, BrainToken::Assign, None),
-            Token::new(8..11, BrainToken::Null, None),
+            Token::new(0..3, BrainToken::Let, "let".to_string()),
+            Token::new(4..5, BrainToken::Identifier, "x".into()),
+            Token::new(6..7, BrainToken::Assign, "=".to_string()),
+            Token::new(8..11, BrainToken::Null, "null".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -273,10 +264,10 @@ mod tests {
     #[test]
     fn parse_assignment_bool() {
         let tokens = vec![
-            Token::new(0..3, BrainToken::Let, None),
-            Token::new(4..5, BrainToken::Identifier, Some("x".into())),
-            Token::new(6..7, BrainToken::Assign, None),
-            Token::new(8..11, BrainToken::True, None),
+            Token::new(0..3, BrainToken::Let, "let".to_string()),
+            Token::new(4..5, BrainToken::Identifier, "x".into()),
+            Token::new(6..7, BrainToken::Assign, "=".to_string()),
+            Token::new(8..11, BrainToken::True, "true".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -296,11 +287,11 @@ mod tests {
     #[test]
     fn parse_assignment_collection() {
         let tokens = vec![
-            Token::new(0..3, BrainToken::Let, None),
-            Token::new(4..5, BrainToken::Identifier, Some("x".into())),
-            Token::new(6..7, BrainToken::Assign, None),
-            Token::new(8..9, BrainToken::LeftBracket, None),
-            Token::new(10..11, BrainToken::RightBracket, None),
+            Token::new(0..3, BrainToken::Let, "let".to_string()),
+            Token::new(4..5, BrainToken::Identifier, "x".into()),
+            Token::new(6..7, BrainToken::Assign, "=".to_string()),
+            Token::new(8..9, BrainToken::LeftBracket, "[".to_string()),
+            Token::new(10..11, BrainToken::RightBracket, "]".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -317,11 +308,11 @@ mod tests {
     #[test]
     fn parse_assignment_map() {
         let tokens = vec![
-            Token::new(0..3, BrainToken::Let, None),
-            Token::new(4..5, BrainToken::Identifier, Some("x".into())),
-            Token::new(6..7, BrainToken::Assign, None),
-            Token::new(8..9, BrainToken::LeftBrace, None),
-            Token::new(10..11, BrainToken::RightBrace, None),
+            Token::new(0..3, BrainToken::Let, "let".to_string()),
+            Token::new(4..5, BrainToken::Identifier, "x".into()),
+            Token::new(6..7, BrainToken::Assign, "=".to_string()),
+            Token::new(8..9, BrainToken::LeftBrace, "{".to_string()),
+            Token::new(10..11, BrainToken::RightBrace, "}".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -337,7 +328,7 @@ mod tests {
 
     #[test]
     fn parse_assignment_eof() {
-        let tokens = vec![Token::new(0..3, BrainToken::Let, None)];
+        let tokens = vec![Token::new(0..3, BrainToken::Let, "let".to_string())];
 
         let stream = &mut TokenStream::from_vec(tokens);
 
@@ -346,7 +337,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.err().unwrap().to_string(),
-            "[UnexpectedEndOfFile]: Expected identifier, found End of File".to_string()
+            "[UnexpectedEndOfFile]: Expected Identifier, but found End of File".to_string()
         );
     }
 }

--- a/brain-grammar/src/grammar/statements/block.rs
+++ b/brain-grammar/src/grammar/statements/block.rs
@@ -134,8 +134,8 @@ mod tests {
     #[test]
     fn parse_block() {
         let tokens = vec![
-            Token::new(0..1, BrainToken::LeftBrace, None),
-            Token::new(1..2, BrainToken::RightBrace, None),
+            Token::new(0..1, BrainToken::LeftBrace, "{".to_string()),
+            Token::new(1..2, BrainToken::RightBrace, "}".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);

--- a/brain-grammar/src/grammar/statements/break.rs
+++ b/brain-grammar/src/grammar/statements/break.rs
@@ -39,7 +39,7 @@ mod test {
 
     #[test]
     fn parse_break() {
-        let tokens = vec![Token::new(0..5, BrainToken::Break, None)];
+        let tokens = vec![Token::new(0..5, BrainToken::Break, "break".to_string())];
 
         let stream = &mut TokenStream::from_vec(tokens);
 

--- a/brain-grammar/src/grammar/statements/conditional.rs
+++ b/brain-grammar/src/grammar/statements/conditional.rs
@@ -488,10 +488,10 @@ mod tests {
     #[test]
     fn parse_conditional() {
         let tokens = vec![
-            Token::new(0..2, BrainToken::If, None),
-            Token::new(3..4, BrainToken::True, None),
-            Token::new(5..6, BrainToken::LeftBrace, None),
-            Token::new(6..7, BrainToken::RightBrace, None),
+            Token::new(0..2, BrainToken::If, "if".to_string()),
+            Token::new(3..4, BrainToken::True, "true".to_string()),
+            Token::new(5..6, BrainToken::LeftBrace, "{".to_string()),
+            Token::new(6..7, BrainToken::RightBrace, "}".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -512,13 +512,13 @@ mod tests {
     #[test]
     fn parse_conditional_with_alternate() {
         let tokens = vec![
-            Token::new(0..2, BrainToken::If, None),
-            Token::new(3..4, BrainToken::True, None),
-            Token::new(5..6, BrainToken::LeftBrace, None),
-            Token::new(6..7, BrainToken::RightBrace, None),
-            Token::new(8..10, BrainToken::Else, None),
-            Token::new(11..12, BrainToken::LeftBrace, None),
-            Token::new(12..13, BrainToken::RightBrace, None),
+            Token::new(0..2, BrainToken::If, "if".to_string()),
+            Token::new(3..4, BrainToken::True, "true".to_string()),
+            Token::new(5..6, BrainToken::LeftBrace, "{".to_string()),
+            Token::new(6..7, BrainToken::RightBrace, "}".to_string()),
+            Token::new(8..10, BrainToken::Else, "else".to_string()),
+            Token::new(11..12, BrainToken::LeftBrace, "{".to_string()),
+            Token::new(12..13, BrainToken::RightBrace, "}".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);

--- a/brain-grammar/src/grammar/statements/continue.rs
+++ b/brain-grammar/src/grammar/statements/continue.rs
@@ -39,7 +39,11 @@ mod test {
 
     #[test]
     fn parse_continue() {
-        let tokens = vec![Token::new(0..7, BrainToken::Continue, None)];
+        let tokens = vec![Token::new(
+            0..7,
+            BrainToken::Continue,
+            "continue".to_string(),
+        )];
 
         let stream = &mut TokenStream::from_vec(tokens);
 

--- a/brain-grammar/src/grammar/statements/for.rs
+++ b/brain-grammar/src/grammar/statements/for.rs
@@ -48,16 +48,7 @@ impl Parse for For {
     fn parse(stream: &mut TokenStream<BrainToken>) -> Result<Self, Box<dyn std::error::Error>> {
         stream.expect(BrainToken::For)?;
 
-        let next = stream.next();
-
-        if next.is_none() {
-            return Err(Error::new(
-                ErrorKind::UnexpectedEndOfFile,
-                "Expected identifier, found End of File".to_string(),
-            ));
-        }
-
-        let data = &next.unwrap().clone().data;
+        let identifier = stream.expect(BrainToken::Identifier)?.clone();
 
         stream.expect(BrainToken::In)?;
 
@@ -65,7 +56,7 @@ impl Parse for For {
 
         let block = Statement::parse(stream)?;
 
-        Ok(Self::new(data.clone().unwrap(), collection, block))
+        Ok(Self::new(identifier.data, collection, block))
     }
 }
 
@@ -194,16 +185,12 @@ mod tests {
     #[test]
     fn parse_loop() {
         let tokens = vec![
-            Token::new(0..3, BrainToken::For, None),
-            Token::new(4..8, BrainToken::Identifier, Some("item".to_string())),
-            Token::new(9..11, BrainToken::In, None),
-            Token::new(
-                12..22,
-                BrainToken::Identifier,
-                Some("collection".to_string()),
-            ),
-            Token::new(23..24, BrainToken::LeftBrace, None),
-            Token::new(25..26, BrainToken::RightBrace, None),
+            Token::new(0..3, BrainToken::For, "for".to_string()),
+            Token::new(4..8, BrainToken::Identifier, "item".to_string()),
+            Token::new(9..11, BrainToken::In, "in".to_string()),
+            Token::new(12..22, BrainToken::Identifier, "collection".to_string()),
+            Token::new(23..24, BrainToken::LeftBrace, "{".to_string()),
+            Token::new(25..26, BrainToken::RightBrace, "}".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -223,7 +210,7 @@ mod tests {
 
     #[test]
     fn parse_loop_eof() {
-        let tokens = vec![Token::new(0..3, BrainToken::For, None)];
+        let tokens = vec![Token::new(0..3, BrainToken::For, "for".to_string())];
 
         let stream = &mut TokenStream::from_vec(tokens);
 
@@ -232,7 +219,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.err().unwrap().to_string(),
-            "[UnexpectedEndOfFile]: Expected identifier, found End of File".to_string()
+            "[UnexpectedEndOfFile]: Expected Identifier, but found End of File".to_string()
         );
     }
 }

--- a/brain-grammar/src/grammar/statements/loop.rs
+++ b/brain-grammar/src/grammar/statements/loop.rs
@@ -78,9 +78,9 @@ mod tests {
     #[test]
     fn parse_loop() {
         let tokens = vec![
-            Token::new(0..4, BrainToken::Loop, None),
-            Token::new(5..6, BrainToken::LeftBrace, None),
-            Token::new(11..12, BrainToken::RightBrace, None),
+            Token::new(0..4, BrainToken::Loop, "loop".to_string()),
+            Token::new(5..6, BrainToken::LeftBrace, "{".to_string()),
+            Token::new(11..12, BrainToken::RightBrace, "}".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);

--- a/brain-grammar/src/grammar/statements/reassignment.rs
+++ b/brain-grammar/src/grammar/statements/reassignment.rs
@@ -40,22 +40,13 @@ impl Resolve for Reassignment {
 
 impl Parse for Reassignment {
     fn parse(stream: &mut TokenStream<BrainToken>) -> Result<Self, Box<dyn std::error::Error>> {
-        let next = stream.next();
-
-        if next.is_none() {
-            return Err(Error::new(
-                ErrorKind::UnexpectedEndOfFile,
-                "Expected identifier, found End of File".to_string(),
-            ));
-        }
-
-        let token = next.unwrap().clone();
+        let identifier = stream.expect(BrainToken::Identifier)?.clone();
 
         stream.expect(BrainToken::Assign)?;
 
         let expression = Expression::parse(stream)?;
 
-        let reassignment = Self::new(token.data.expect("Identifier should have data"), expression);
+        let reassignment = Self::new(identifier.data, expression);
 
         stream.skip_if(BrainToken::Semicolon);
 
@@ -220,9 +211,9 @@ mod tests {
     #[test]
     fn parse_assignment() {
         let tokens = vec![
-            Token::new(0..1, BrainToken::Identifier, Some("x".to_string())),
-            Token::new(0..1, BrainToken::Assign, None),
-            Token::new(0..1, BrainToken::String, Some("hello".to_string())),
+            Token::new(0..1, BrainToken::Identifier, "x".to_string()),
+            Token::new(0..1, BrainToken::Assign, "=".to_string()),
+            Token::new(0..1, BrainToken::String, "hello".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -242,9 +233,9 @@ mod tests {
     #[test]
     fn parse_reassignment_number() {
         let tokens = vec![
-            Token::new(0..1, BrainToken::Identifier, Some("x".to_string())),
-            Token::new(0..1, BrainToken::Assign, None),
-            Token::new(0..1, BrainToken::Number, Some("1".to_string())),
+            Token::new(0..1, BrainToken::Identifier, "x".to_string()),
+            Token::new(0..1, BrainToken::Assign, "=".to_string()),
+            Token::new(0..1, BrainToken::Number, "1".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -261,9 +252,9 @@ mod tests {
     #[test]
     fn parse_reassignment_null() {
         let tokens = vec![
-            Token::new(0..1, BrainToken::Identifier, Some("x".to_string())),
-            Token::new(0..1, BrainToken::Assign, None),
-            Token::new(0..1, BrainToken::Null, None),
+            Token::new(0..1, BrainToken::Identifier, "x".to_string()),
+            Token::new(0..1, BrainToken::Assign, "=".to_string()),
+            Token::new(0..1, BrainToken::Null, "null".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -280,9 +271,9 @@ mod tests {
     #[test]
     fn parse_reassignment_bool() {
         let tokens = vec![
-            Token::new(0..1, BrainToken::Identifier, Some("x".to_string())),
-            Token::new(0..1, BrainToken::Assign, None),
-            Token::new(0..1, BrainToken::True, None),
+            Token::new(0..1, BrainToken::Identifier, "x".to_string()),
+            Token::new(0..1, BrainToken::Assign, "=".to_string()),
+            Token::new(0..1, BrainToken::True, "true".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -302,10 +293,10 @@ mod tests {
     #[test]
     fn parse_reassignment_collection() {
         let tokens = vec![
-            Token::new(0..1, BrainToken::Identifier, Some("x".to_string())),
-            Token::new(0..1, BrainToken::Assign, None),
-            Token::new(0..1, BrainToken::LeftBracket, None),
-            Token::new(0..1, BrainToken::RightBracket, None),
+            Token::new(0..1, BrainToken::Identifier, "x".to_string()),
+            Token::new(0..1, BrainToken::Assign, "=".to_string()),
+            Token::new(0..1, BrainToken::LeftBracket, "[".to_string()),
+            Token::new(0..1, BrainToken::RightBracket, "]".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -322,10 +313,10 @@ mod tests {
     #[test]
     fn parse_reassignment_map() {
         let tokens = vec![
-            Token::new(0..1, BrainToken::Identifier, Some("x".to_string())),
-            Token::new(0..1, BrainToken::Assign, None),
-            Token::new(0..1, BrainToken::LeftBrace, None),
-            Token::new(0..1, BrainToken::RightBrace, None),
+            Token::new(0..1, BrainToken::Identifier, "x".to_string()),
+            Token::new(0..1, BrainToken::Assign, "=".to_string()),
+            Token::new(0..1, BrainToken::LeftBrace, "{".to_string()),
+            Token::new(0..1, BrainToken::RightBrace, "}".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -350,7 +341,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.err().unwrap().to_string(),
-            "[UnexpectedEndOfFile]: Expected identifier, found End of File".to_string()
+            "[UnexpectedEndOfFile]: Expected Identifier, but found End of File".to_string()
         );
     }
 }

--- a/brain-grammar/src/grammar/statements/return.rs
+++ b/brain-grammar/src/grammar/statements/return.rs
@@ -68,8 +68,8 @@ mod tests {
     #[test]
     fn parse_return() {
         let tokens = vec![
-            Token::new(0..6, BrainToken::Return, None),
-            Token::new(7..8, BrainToken::Number, Some("0".to_string())),
+            Token::new(0..6, BrainToken::Return, "return".to_string()),
+            Token::new(7..8, BrainToken::Number, "0".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);

--- a/brain-grammar/src/grammar/util.rs
+++ b/brain-grammar/src/grammar/util.rs
@@ -22,8 +22,8 @@ mod test {
     #[test]
     fn reassignment() {
         let tokens = vec![
-            Token::new(0..1, BrainToken::Identifier, Some("a".to_string())),
-            Token::new(2..3, BrainToken::Assign, None),
+            Token::new(0..1, BrainToken::Identifier, "a".to_string()),
+            Token::new(2..3, BrainToken::Assign, "=".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -34,8 +34,8 @@ mod test {
     #[test]
     fn equality() {
         let tokens = vec![
-            Token::new(0..1, BrainToken::Identifier, Some("a".to_string())),
-            Token::new(2..3, BrainToken::Equal, None),
+            Token::new(0..1, BrainToken::Identifier, "a".to_string()),
+            Token::new(2..3, BrainToken::Equal, "==".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);

--- a/brain-token/src/lexer.rs
+++ b/brain-token/src/lexer.rs
@@ -63,7 +63,7 @@ where
                     self.tokens.push(Token::new(
                         span.clone(),
                         literal.token.clone(),
-                        Some(next.to_string()),
+                        next.to_string(),
                     ));
                     self.current += next.len();
                     self.skip_whitespace();
@@ -89,7 +89,7 @@ where
                     self.tokens.push(Token::new(
                         span.clone(),
                         regex_attribute.token.clone(),
-                        Some(capture.to_string()),
+                        capture.to_string(),
                     ));
                     self.current += capture.len();
                     self.skip_whitespace();
@@ -163,7 +163,7 @@ mod tests {
             TokenStream::<TestToken>::from_vec(vec![Token::new(
                 0..4,
                 TestToken::Literal,
-                Some("test".to_string())
+                "test".to_string()
             )])
         );
     }
@@ -182,7 +182,7 @@ mod tests {
             TokenStream::<TestToken>::from_vec(vec![Token::new(
                 0..4,
                 TestToken::Regex,
-                Some("test".to_string())
+                "test".to_string()
             )])
         );
     }
@@ -201,8 +201,8 @@ mod tests {
         assert_eq!(
             tokens,
             TokenStream::<TestToken>::from_vec(vec![
-                Token::new(0..1, TestToken::Literal, Some("a".to_string())),
-                Token::new(2..8, TestToken::Regex, Some("string".to_string()))
+                Token::new(0..1, TestToken::Literal, "a".to_string()),
+                Token::new(2..8, TestToken::Regex, "string".to_string())
             ])
         );
     }

--- a/brain-token/src/stream.rs
+++ b/brain-token/src/stream.rs
@@ -32,12 +32,32 @@ where
         next
     }
 
+    pub fn assert_next(&mut self, error: String) -> Result<&Token<T>, Box<dyn std::error::Error>> {
+        let token = self.next();
+
+        if token.is_none() {
+            return Err(Error::new(ErrorKind::UnexpectedEndOfFile, error));
+        }
+
+        return Ok(token.unwrap());
+    }
+
     pub fn skip(&mut self) {
         self.next();
     }
 
     pub fn peek(&self) -> Option<&Token<T>> {
         self.stream.get(self.position)
+    }
+
+    pub fn assert_peek(&self, error: String) -> Result<&Token<T>, Box<dyn std::error::Error>> {
+        let token = self.peek();
+
+        if token.is_none() {
+            return Err(Error::new(ErrorKind::UnexpectedEndOfFile, error));
+        }
+
+        return Ok(token.unwrap());
     }
 
     pub fn double_peek(&self) -> (Option<&Token<T>>, Option<&Token<T>>) {
@@ -51,10 +71,10 @@ where
         self.stream.push(token)
     }
 
-    pub fn expect(&mut self, token: T) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn expect(&mut self, token: T) -> Result<&Token<T>, Box<dyn std::error::Error>> {
         if let Some(next) = self.next() {
             if token == next.token {
-                return Ok(());
+                return Ok(next);
             }
 
             return Err(Error::new(
@@ -117,12 +137,12 @@ mod tests {
     fn push() {
         let stream = &mut TokenStream::<BrainToken>::new();
 
-        stream.push(Token::new(0..2, BrainToken::Let, None));
+        stream.push(Token::new(0..2, BrainToken::Let, "let".to_string()));
 
         assert_eq!(
             stream,
             &mut TokenStream {
-                stream: vec![Token::new(0..2, BrainToken::Let, None)],
+                stream: vec![Token::new(0..2, BrainToken::Let, "let".to_string())],
                 position: 0,
             }
         )
@@ -131,81 +151,93 @@ mod tests {
     #[test]
     fn peek() {
         let tokens = vec![
-            Token::new(0..2, BrainToken::Let, None),
-            Token::new(0..2, BrainToken::Identifier, Some("x".to_string())),
-            Token::new(0..2, BrainToken::Assign, None),
-            Token::new(0..2, BrainToken::Number, Some("0".to_string())),
+            Token::new(0..2, BrainToken::Let, "let".to_string()),
+            Token::new(0..2, BrainToken::Identifier, "x".to_string()),
+            Token::new(0..2, BrainToken::Assign, "=".to_string()),
+            Token::new(0..2, BrainToken::Number, "0".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
 
         let peek = stream.peek();
 
-        assert_eq!(peek.unwrap(), &Token::new(0..2, BrainToken::Let, None));
+        assert_eq!(
+            peek.unwrap(),
+            &Token::new(0..2, BrainToken::Let, "let".to_string())
+        );
     }
 
     #[test]
     fn multiple_peek() {
         let tokens = vec![
-            Token::new(0..2, BrainToken::Let, None),
-            Token::new(0..2, BrainToken::Identifier, Some("x".to_string())),
-            Token::new(0..2, BrainToken::Assign, None),
-            Token::new(0..2, BrainToken::Number, Some("0".to_string())),
+            Token::new(0..2, BrainToken::Let, "let".to_string()),
+            Token::new(0..2, BrainToken::Identifier, "x".to_string()),
+            Token::new(0..2, BrainToken::Assign, "=".to_string()),
+            Token::new(0..2, BrainToken::Number, "0".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
 
         let mut peek = stream.peek();
 
-        assert_eq!(peek.unwrap(), &Token::new(0..2, BrainToken::Let, None));
+        assert_eq!(
+            peek.unwrap(),
+            &Token::new(0..2, BrainToken::Let, "let".to_string())
+        );
 
         peek = stream.peek();
 
-        assert_eq!(peek.unwrap(), &Token::new(0..2, BrainToken::Let, None));
+        assert_eq!(
+            peek.unwrap(),
+            &Token::new(0..2, BrainToken::Let, "let".to_string())
+        );
     }
 
     #[test]
     fn next() {
         let tokens = vec![
-            Token::new(0..2, BrainToken::Let, None),
-            Token::new(0..2, BrainToken::Identifier, Some("x".to_string())),
-            Token::new(0..2, BrainToken::Assign, None),
-            Token::new(0..2, BrainToken::Number, Some("0".to_string())),
+            Token::new(0..2, BrainToken::Let, "let".to_string()),
+            Token::new(0..2, BrainToken::Identifier, "x".to_string()),
+            Token::new(0..2, BrainToken::Assign, "=".to_string()),
+            Token::new(0..2, BrainToken::Number, "0".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
 
         let next = stream.next();
 
-        assert_eq!(next.unwrap(), &Token::new(0..2, BrainToken::Let, None));
+        assert_eq!(
+            next.unwrap(),
+            &Token::new(0..2, BrainToken::Let, "let".to_string())
+        );
     }
 
     #[test]
     fn next_consume_stream() {
         let tokens = vec![
-            Token::new(0..2, BrainToken::Let, None),
-            Token::new(0..2, BrainToken::Identifier, Some("x".to_string())),
-            Token::new(0..2, BrainToken::Assign, None),
-            Token::new(0..2, BrainToken::Number, Some("0".to_string())),
+            Token::new(0..2, BrainToken::Let, "let".to_string()),
+            Token::new(0..2, BrainToken::Identifier, "x".to_string()),
+            Token::new(0..2, BrainToken::Assign, "=".to_string()),
+            Token::new(0..2, BrainToken::Number, "0".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
 
         assert_eq!(
             stream.next().unwrap(),
-            &Token::new(0..2, BrainToken::Let, None)
+            &Token::new(0..2, BrainToken::Let, "let".to_string())
         );
         assert_eq!(
             stream.next().unwrap(),
-            &Token::new(0..2, BrainToken::Identifier, Some("x".to_string()))
+            &Token::new(0..2, BrainToken::Identifier, "x".to_string())
         );
         assert_eq!(
             stream.next().unwrap(),
-            &Token::new(0..2, BrainToken::Assign, None)
+            &Token::new(0..2, BrainToken::Assign, "=".to_string())
         );
         assert_eq!(
             stream.next().unwrap(),
-            &Token::new(0..2, BrainToken::Number, Some("0".to_string()))
+            &Token::new(0..2, BrainToken::Number, "0".to_string())
         );
         assert!(stream.next().is_none());
     }
@@ -213,10 +245,10 @@ mod tests {
     #[test]
     fn skip() {
         let tokens = vec![
-            Token::new(0..2, BrainToken::Let, None),
-            Token::new(0..2, BrainToken::Identifier, Some("x".to_string())),
-            Token::new(0..2, BrainToken::Assign, None),
-            Token::new(0..2, BrainToken::Number, Some("0".to_string())),
+            Token::new(0..2, BrainToken::Let, "let".to_string()),
+            Token::new(0..2, BrainToken::Identifier, "x".to_string()),
+            Token::new(0..2, BrainToken::Assign, "=".to_string()),
+            Token::new(0..2, BrainToken::Number, "0".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -225,17 +257,17 @@ mod tests {
 
         assert_eq!(
             stream.peek().unwrap(),
-            &Token::new(0..2, BrainToken::Identifier, Some("x".to_string()))
+            &Token::new(0..2, BrainToken::Identifier, "x".to_string())
         );
     }
 
     #[test]
     fn skip_consume_stream() {
         let tokens = vec![
-            Token::new(0..2, BrainToken::Let, None),
-            Token::new(0..2, BrainToken::Identifier, Some("x".to_string())),
-            Token::new(0..2, BrainToken::Assign, None),
-            Token::new(0..2, BrainToken::Number, Some("0".to_string())),
+            Token::new(0..2, BrainToken::Let, "let".to_string()),
+            Token::new(0..2, BrainToken::Identifier, "x".to_string()),
+            Token::new(0..2, BrainToken::Assign, "=".to_string()),
+            Token::new(0..2, BrainToken::Number, "0".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -251,10 +283,10 @@ mod tests {
     #[test]
     fn expect() {
         let tokens = vec![
-            Token::new(0..2, BrainToken::Let, None),
-            Token::new(0..2, BrainToken::Identifier, Some("x".to_string())),
-            Token::new(0..2, BrainToken::Assign, None),
-            Token::new(0..2, BrainToken::Number, Some("0".to_string())),
+            Token::new(0..2, BrainToken::Let, "let".to_string()),
+            Token::new(0..2, BrainToken::Identifier, "x".to_string()),
+            Token::new(0..2, BrainToken::Assign, "=".to_string()),
+            Token::new(0..2, BrainToken::Number, "0".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -265,10 +297,10 @@ mod tests {
     #[test]
     fn expect_consume_stream() {
         let tokens = vec![
-            Token::new(0..2, BrainToken::Let, None),
-            Token::new(0..2, BrainToken::Identifier, Some("x".to_string())),
-            Token::new(0..2, BrainToken::Assign, None),
-            Token::new(0..2, BrainToken::Number, Some("0".to_string())),
+            Token::new(0..2, BrainToken::Let, "let".to_string()),
+            Token::new(0..2, BrainToken::Identifier, "x".to_string()),
+            Token::new(0..2, BrainToken::Assign, "=".to_string()),
+            Token::new(0..2, BrainToken::Number, "0".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -282,10 +314,10 @@ mod tests {
     #[test]
     fn expect_wrong_token() {
         let tokens = vec![
-            Token::new(0..2, BrainToken::Let, None),
-            Token::new(0..2, BrainToken::Identifier, Some("x".to_string())),
-            Token::new(0..2, BrainToken::Assign, None),
-            Token::new(0..2, BrainToken::Number, Some("0".to_string())),
+            Token::new(0..2, BrainToken::Let, "let".to_string()),
+            Token::new(0..2, BrainToken::Identifier, "x".to_string()),
+            Token::new(0..2, BrainToken::Assign, "=".to_string()),
+            Token::new(0..2, BrainToken::Number, "0".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -317,10 +349,10 @@ mod tests {
     #[test]
     fn check() {
         let tokens = vec![
-            Token::new(0..2, BrainToken::Let, None),
-            Token::new(0..2, BrainToken::Identifier, Some("x".to_string())),
-            Token::new(0..2, BrainToken::Assign, None),
-            Token::new(0..2, BrainToken::Number, Some("0".to_string())),
+            Token::new(0..2, BrainToken::Let, "let".to_string()),
+            Token::new(0..2, BrainToken::Identifier, "x".to_string()),
+            Token::new(0..2, BrainToken::Assign, "=".to_string()),
+            Token::new(0..2, BrainToken::Number, "0".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -332,10 +364,10 @@ mod tests {
     #[test]
     fn skip_if() {
         let tokens = vec![
-            Token::new(0..2, BrainToken::Let, None),
-            Token::new(0..2, BrainToken::Identifier, Some("x".to_string())),
-            Token::new(0..2, BrainToken::Assign, None),
-            Token::new(0..2, BrainToken::Number, Some("0".to_string())),
+            Token::new(0..2, BrainToken::Let, "let".to_string()),
+            Token::new(0..2, BrainToken::Identifier, "x".to_string()),
+            Token::new(0..2, BrainToken::Assign, "=".to_string()),
+            Token::new(0..2, BrainToken::Number, "0".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -344,17 +376,17 @@ mod tests {
 
         assert_ne!(
             stream.peek().unwrap(),
-            &Token::new(0..2, BrainToken::Let, None)
+            &Token::new(0..2, BrainToken::Let, "let".to_string())
         );
     }
 
     #[test]
     fn double_peek() {
         let tokens = vec![
-            Token::new(0..2, BrainToken::Let, None),
-            Token::new(0..2, BrainToken::Identifier, Some("x".to_string())),
-            Token::new(0..2, BrainToken::Assign, None),
-            Token::new(0..2, BrainToken::Number, Some("0".to_string())),
+            Token::new(0..2, BrainToken::Let, "let".to_string()),
+            Token::new(0..2, BrainToken::Identifier, "x".to_string()),
+            Token::new(0..2, BrainToken::Assign, "=".to_string()),
+            Token::new(0..2, BrainToken::Number, "0".to_string()),
         ];
 
         let stream = &mut TokenStream::from_vec(tokens);
@@ -364,12 +396,8 @@ mod tests {
         assert_eq!(
             peek,
             (
-                Some(&Token::new(0..2, BrainToken::Let, None)),
-                Some(&Token::new(
-                    0..2,
-                    BrainToken::Identifier,
-                    Some("x".to_string())
-                ))
+                Some(&Token::new(0..2, BrainToken::Let, "let".to_string())),
+                Some(&Token::new(0..2, BrainToken::Identifier, "x".to_string()))
             )
         )
     }

--- a/brain-token/src/stream.rs
+++ b/brain-token/src/stream.rs
@@ -194,6 +194,33 @@ mod tests {
     }
 
     #[test]
+    fn assert_peek() {
+        let tokens = vec![
+            Token::new(0..2, BrainToken::Let, "let".to_string()),
+            Token::new(0..2, BrainToken::Identifier, "x".to_string()),
+            Token::new(0..2, BrainToken::Assign, "=".to_string()),
+            Token::new(0..2, BrainToken::Number, "0".to_string()),
+        ];
+
+        let stream = &mut TokenStream::from_vec(tokens);
+
+        let peek = stream.assert_peek("no error".to_string());
+
+        assert!(peek.is_ok())
+    }
+
+    #[test]
+    fn assert_peek_doesnt_exist() {
+        let tokens: Vec<Token<BrainToken>> = vec![];
+
+        let stream = &mut TokenStream::from_vec(tokens);
+
+        let peek = stream.assert_peek("for sure error".to_string());
+
+        assert!(peek.is_err())
+    }
+
+    #[test]
     fn next() {
         let tokens = vec![
             Token::new(0..2, BrainToken::Let, "let".to_string()),
@@ -240,6 +267,33 @@ mod tests {
             &Token::new(0..2, BrainToken::Number, "0".to_string())
         );
         assert!(stream.next().is_none());
+    }
+
+    #[test]
+    fn assert_next() {
+        let tokens = vec![
+            Token::new(0..2, BrainToken::Let, "let".to_string()),
+            Token::new(0..2, BrainToken::Identifier, "x".to_string()),
+            Token::new(0..2, BrainToken::Assign, "=".to_string()),
+            Token::new(0..2, BrainToken::Number, "0".to_string()),
+        ];
+
+        let stream = &mut TokenStream::from_vec(tokens);
+
+        let token = stream.assert_next("no error".to_string());
+
+        assert!(token.is_ok());
+    }
+
+    #[test]
+    fn assert_next_no_further_tokens() {
+        let tokens: Vec<Token<BrainToken>> = vec![];
+
+        let stream = &mut TokenStream::from_vec(tokens);
+
+        let token = stream.assert_next("for sure error".to_string());
+
+        assert!(token.is_err());
     }
 
     #[test]
@@ -291,7 +345,10 @@ mod tests {
 
         let stream = &mut TokenStream::from_vec(tokens);
 
-        assert!(stream.expect(BrainToken::Let).is_ok())
+        let token = stream.expect(BrainToken::Let);
+
+        assert!(token.is_ok());
+        assert_eq!(token.unwrap().data, "let".to_string());
     }
 
     #[test]

--- a/brain-token/src/token.rs
+++ b/brain-token/src/token.rs
@@ -4,14 +4,14 @@ pub type Span = std::ops::Range<usize>;
 pub struct Token<T> {
     pub span: Span,
     pub token: T,
-    pub data: Option<String>,
+    pub data: String,
 }
 
 impl<T> Token<T>
 where
     T: Clone + std::fmt::Debug + PartialEq,
 {
-    pub fn new(span: Span, token: T, data: Option<String>) -> Self {
+    pub fn new(span: Span, token: T, data: String) -> Self {
         Token { span, token, data }
     }
 }
@@ -28,19 +28,19 @@ mod tests {
 
     #[test]
     fn new() {
-        let token = Token::new(0..2, Test::A, None);
+        let token = Token::new(0..2, Test::A, "".to_string());
 
         assert_eq!(token.span, 0..2);
         assert_eq!(token.token, Test::A);
-        assert_eq!(token.data, None);
+        assert_eq!(token.data, "".to_string());
     }
 
     #[test]
     fn new_with_data() {
-        let token = Token::new(0..2, Test::B, Some("test".to_string()));
+        let token = Token::new(0..2, Test::B, "test".to_string());
 
         assert_eq!(token.span, 0..2);
         assert_eq!(token.token, Test::B);
-        assert_eq!(token.data, Some("test".to_string()));
+        assert_eq!(token.data, "test".to_string());
     }
 }

--- a/tests/src/attribute.rs
+++ b/tests/src/attribute.rs
@@ -29,10 +29,10 @@ mod tests {
         let input = "let first = 0".to_string();
 
         let expected_tokens = vec![
-            Token::new(0..3, BrainToken::Let, Some("let".to_string())),
-            Token::new(4..9, BrainToken::Identifier, Some("first".to_string())),
-            Token::new(10..11, BrainToken::Assign, Some("=".to_string())),
-            Token::new(12..13, BrainToken::Number, Some("0".to_string())),
+            Token::new(0..3, BrainToken::Let, "let".to_string()),
+            Token::new(4..9, BrainToken::Identifier, "first".to_string()),
+            Token::new(10..11, BrainToken::Assign, "=".to_string()),
+            Token::new(12..13, BrainToken::Number, "0".to_string()),
         ];
 
         let expected_stream = TokenStream::from_vec(expected_tokens);
@@ -47,9 +47,9 @@ mod tests {
         let input = "x = 0".to_string();
 
         let expected_tokens = vec![
-            Token::new(0..1, BrainToken::Identifier, Some("x".to_string())),
-            Token::new(2..3, BrainToken::Assign, Some("=".to_string())),
-            Token::new(4..5, BrainToken::Number, Some("0".to_string())),
+            Token::new(0..1, BrainToken::Identifier, "x".to_string()),
+            Token::new(2..3, BrainToken::Assign, "=".to_string()),
+            Token::new(4..5, BrainToken::Number, "0".to_string()),
         ];
 
         let expected_stream = TokenStream::from_vec(expected_tokens);
@@ -64,10 +64,10 @@ mod tests {
         let input = r#"let x = "hello""#.to_string();
 
         let expected_tokens = vec![
-            Token::new(0..3, BrainToken::Let, Some("let".to_string())),
-            Token::new(4..5, BrainToken::Identifier, Some("x".to_string())),
-            Token::new(6..7, BrainToken::Assign, Some("=".to_string())),
-            Token::new(8..15, BrainToken::String, Some(r#""hello""#.to_string())),
+            Token::new(0..3, BrainToken::Let, "let".to_string()),
+            Token::new(4..5, BrainToken::Identifier, "x".to_string()),
+            Token::new(6..7, BrainToken::Assign, "=".to_string()),
+            Token::new(8..15, BrainToken::String, r#""hello""#.to_string()),
         ];
 
         let expected_stream = TokenStream::from_vec(expected_tokens);


### PR DESCRIPTION
* token data is no longer optional. all tokens must have associated data.
* streams now have assertions for its accessor types that return a result, allowing you to safely engage with the inner token.
* `stream.expect` returns the token expected if it exists. 

all of these should provide a simpler experience when parsing tokens. 