### PR TITLE
Tuples

### DIFF
--- a/brain-error/src/lib.rs
+++ b/brain-error/src/lib.rs
@@ -18,6 +18,7 @@ pub enum ErrorKind {
     UnexpectedToken,
     UnexpectedEndOfFile,
     ParseError,
+    ImmutableValue,
 }
 
 impl fmt::Display for ErrorKind {
@@ -39,6 +40,7 @@ impl fmt::Display for ErrorKind {
             ErrorKind::UnexpectedEndOfFile => write!(f, "UnexpectedEndOfFile"),
             ErrorKind::UnexpectedExpression => write!(f, "UnexpectedExpression"),
             ErrorKind::ParseError => write!(f, "ParseError"),
+            ErrorKind::ImmutableValue => write!(f, "ImmutableValue"),
         }
     }
 }

--- a/brain-grammar/src/grammar/expressions/accessors/index.rs
+++ b/brain-grammar/src/grammar/expressions/accessors/index.rs
@@ -77,6 +77,42 @@ impl Evaluate for Index {
                     )),
                 }
             }
+            Value::Complex(ComplexValue::Tuple(tuple)) => {
+                let index = self.index.evaluate(context)?;
+                let values = tuple.values.clone();
+
+                match index {
+                    Value::Literal(LiteralValue::Number(index)) => {
+                        if index < 0 {
+                            return Err(Error::new(
+                                ErrorKind::IndexOutOfBounds,
+                                format!(
+                                    "Index {} is out of bounds (length of {})",
+                                    index,
+                                    values.len()
+                                ),
+                            ));
+                        }
+
+                        if index >= (values.len() as i64) {
+                            return Err(Error::new(
+                                ErrorKind::IndexOutOfBounds,
+                                format!(
+                                    "Index {} is out of bounds (length of {})",
+                                    index,
+                                    values.len()
+                                ),
+                            ));
+                        }
+
+                        Ok(values[index as usize].clone())
+                    }
+                    _ => Err(Error::new(
+                        ErrorKind::InvalidType,
+                        format!("Index must be a number, not '{index}'"),
+                    )),
+                }
+            }
             Value::Complex(ComplexValue::Map(map)) => {
                 let key = self.index.evaluate(context)?;
 

--- a/brain-grammar/src/grammar/expressions/collection.rs
+++ b/brain-grammar/src/grammar/expressions/collection.rs
@@ -52,7 +52,6 @@ impl Parse for Collection {
 
 #[cfg(test)]
 mod tests {
-
     use brain_token::token::Token;
 
     use super::*;

--- a/brain-grammar/src/grammar/expressions/mod.rs
+++ b/brain-grammar/src/grammar/expressions/mod.rs
@@ -8,6 +8,7 @@ use crate::grammar::{context::Context, value::Value};
 use self::{
     accessors::Accessor, binary::Binary, collection::Collection, functioncall::FunctionCall,
     identifier::Identifier, literal::Literal, map::Map, operator::Operator, r#enum::Enum,
+    tuple::Tuple,
 };
 
 use super::{token::BrainToken, Evaluate, Match, Parse};
@@ -34,6 +35,7 @@ pub enum Expression {
     Accessor(Accessor),
     Enum(Enum),
     Map(Map),
+    Tuple(Tuple),
 }
 
 impl fmt::Display for Expression {
@@ -47,6 +49,7 @@ impl fmt::Display for Expression {
             Expression::Accessor(_) => write!(f, "accessor"),
             Expression::Map(_) => write!(f, "map"),
             Expression::Enum(_) => write!(f, "enum"),
+            Expression::Tuple(_) => write!(f, "tuple"),
         }
     }
 }
@@ -83,6 +86,10 @@ impl Expression {
     pub fn new_index_accessor(index: Expression, target: Expression) -> Self {
         Expression::Accessor(Accessor::new_index(index, target))
     }
+
+    pub fn new_tuple(values: Vec<Expression>) -> Self {
+        Expression::Tuple(Tuple::new(values))
+    }
 }
 
 impl Evaluate for Expression {
@@ -96,6 +103,7 @@ impl Evaluate for Expression {
             Expression::Map(map) => map.evaluate(context),
             Expression::Accessor(accessor) => accessor.evaluate(context),
             Expression::Enum(r#enum) => r#enum.evaluate(context),
+            Expression::Tuple(tuple) => tuple.evaluate(context),
         }
     }
 }
@@ -111,8 +119,6 @@ impl Parse for Expression {
 
         if Literal::matches(token) {
             let literal = Literal::parse(stream)?;
-
-            println!("Literal: {:?}", literal);
 
             let next = stream.peek();
 
@@ -132,6 +138,10 @@ impl Parse for Expression {
 
         if stream.check(BrainToken::LeftBrace) {
             return Ok(Self::Map(Map::parse(stream)?));
+        }
+
+        if stream.check(BrainToken::LeftParen) {
+            return Ok(Self::Tuple(Tuple::parse(stream)?));
         }
 
         if let &BrainToken::Identifier = &next.token {
@@ -446,6 +456,50 @@ mod tests {
         let stream = &mut TokenStream::from_vec(tokens);
 
         let result = Map::parse(stream);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn new_expression_tuple() {
+        let expression = Expression::new_tuple(vec![
+            Expression::new_literal(Value::new_number(1)),
+            Expression::new_literal(Value::new_number(2)),
+        ]);
+        assert_eq!(
+            expression,
+            Expression::Tuple(Tuple::new(vec![
+                Expression::new_literal(Value::new_number(1)),
+                Expression::new_literal(Value::new_number(2)),
+            ]))
+        );
+    }
+
+    #[test]
+    fn eval_expression_tuple() {
+        let context = &mut Context::new();
+        let expression = Expression::new_tuple(vec![
+            Expression::new_literal(Value::new_number(1)),
+            Expression::new_literal(Value::new_number(2)),
+        ]);
+
+        let result = expression.evaluate(context);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn parse_tuple() {
+        let tokens = vec![
+            Token::new(0..1, BrainToken::LeftParen, "(".to_string()),
+            Token::new(1..2, BrainToken::Number, "1".to_string()),
+            Token::new(2..3, BrainToken::Comma, ",".to_string()),
+            Token::new(3..4, BrainToken::Number, "2".to_string()),
+            Token::new(4..5, BrainToken::RightParen, ")".to_string()),
+        ];
+
+        let stream = &mut TokenStream::from_vec(tokens);
+
+        let result = Tuple::parse(stream);
 
         assert!(result.is_ok());
     }

--- a/brain-grammar/src/grammar/expressions/mod.rs
+++ b/brain-grammar/src/grammar/expressions/mod.rs
@@ -22,6 +22,7 @@ pub mod identifier;
 pub mod literal;
 pub mod map;
 pub mod operator;
+pub mod tuple;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Expression {

--- a/brain-grammar/src/grammar/expressions/tuple.rs
+++ b/brain-grammar/src/grammar/expressions/tuple.rs
@@ -1,0 +1,48 @@
+use brain_token::stream::TokenStream;
+
+use crate::grammar::{context::Context, token::BrainToken, value::Value, Evaluate, Parse};
+
+use super::Expression;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
+pub struct Tuple {
+    pub value: Vec<Expression>,
+}
+
+impl Tuple {
+    pub fn new(values: Vec<Expression>) -> Self {
+        Self { value: values }
+    }
+}
+
+impl Parse for Tuple {
+    fn parse(stream: &mut TokenStream<BrainToken>) -> Result<Self, Box<dyn std::error::Error>> {
+        stream.expect(BrainToken::LeftParen)?;
+
+        let mut values = Vec::new();
+
+        while !stream.check(BrainToken::RightParen) {
+            values.push(Expression::parse(stream)?);
+
+            stream.skip_if(BrainToken::Comma);
+        }
+
+        stream.expect(BrainToken::RightParen)?;
+
+        stream.skip_if(BrainToken::Semicolon);
+
+        Ok(Self::new(values))
+    }
+}
+
+impl Evaluate for Tuple {
+    fn evaluate(&self, context: &mut Context) -> Result<Value, Box<dyn std::error::Error>> {
+        let mut values = Vec::new();
+
+        for value in &self.value {
+            values.push(value.evaluate(context)?);
+        }
+
+        Ok(Value::Tuple(values))
+    }
+}

--- a/brain-grammar/src/grammar/expressions/tuple.rs
+++ b/brain-grammar/src/grammar/expressions/tuple.rs
@@ -6,12 +6,12 @@ use super::Expression;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct Tuple {
-    pub value: Vec<Expression>,
+    pub values: Vec<Expression>,
 }
 
 impl Tuple {
     pub fn new(values: Vec<Expression>) -> Self {
-        Self { value: values }
+        Self { values }
     }
 }
 
@@ -39,10 +39,73 @@ impl Evaluate for Tuple {
     fn evaluate(&self, context: &mut Context) -> Result<Value, Box<dyn std::error::Error>> {
         let mut values = Vec::new();
 
-        for value in &self.value {
+        for value in &self.values {
             values.push(value.evaluate(context)?);
         }
 
-        Ok(Value::Tuple(values))
+        Ok(Value::new_tuple(values))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use brain_token::token::Token;
+
+    use super::*;
+
+    #[test]
+    fn create_new_tuple() {
+        let tuple = Tuple::new(vec![
+            Expression::new_literal(Value::new_number(1)),
+            Expression::new_literal(Value::new_number(2)),
+            Expression::new_literal(Value::new_number(3)),
+        ]);
+        assert_eq!(
+            tuple.values,
+            vec![
+                Expression::new_literal(Value::new_number(1)),
+                Expression::new_literal(Value::new_number(2)),
+                Expression::new_literal(Value::new_number(3)),
+            ]
+        );
+    }
+
+    #[test]
+    fn eval_tuple() {
+        let context = &mut Context::new();
+        let collection = Tuple::new(vec![
+            Expression::new_literal(Value::new_number(1)),
+            Expression::new_literal(Value::new_number(2)),
+            Expression::new_literal(Value::new_number(3)),
+        ]);
+
+        let result = collection.evaluate(context);
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            Value::new_tuple(vec![
+                Value::new_number(1),
+                Value::new_number(2),
+                Value::new_number(3),
+            ])
+        );
+    }
+
+    #[test]
+    fn parse_tuple() {
+        let tokens = vec![
+            Token::new(0..1, BrainToken::LeftParen, "(".to_string()),
+            Token::new(1..2, BrainToken::Number, "0".to_string()),
+            Token::new(2..3, BrainToken::RightParen, ")".to_string()),
+        ];
+
+        let stream = &mut TokenStream::from_vec(tokens);
+
+        let result = Tuple::parse(stream);
+
+        assert_eq!(
+            result.unwrap(),
+            Tuple::new(vec![Expression::new_literal(Value::new_number(0))])
+        );
     }
 }

--- a/brain-grammar/src/grammar/statements/reassignment.rs
+++ b/brain-grammar/src/grammar/statements/reassignment.rs
@@ -2,8 +2,12 @@ use brain_error::{Error, ErrorKind};
 use brain_token::stream::TokenStream;
 
 use crate::grammar::{
-    context::Context, expressions::Expression, output::Output, token::BrainToken, Evaluate, Parse,
-    Resolve,
+    context::Context,
+    expressions::Expression,
+    output::Output,
+    token::BrainToken,
+    value::{complex::ComplexValue, Value},
+    Evaluate, Parse, Resolve,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -14,10 +18,7 @@ pub struct Reassignment {
 
 impl Reassignment {
     pub fn new(target: String, value: Expression) -> Self {
-        Reassignment {
-            target: target,
-            value: value,
-        }
+        Reassignment { target, value }
     }
 }
 
@@ -29,6 +30,13 @@ impl Resolve for Reassignment {
             return Err(Error::new(
                 ErrorKind::UnknownIdentifier,
                 format!("'{}'", self.target),
+            ));
+        }
+
+        if let Value::Complex(ComplexValue::Tuple(_)) = value {
+            return Err(Error::new(
+                ErrorKind::ImmutableValue,
+                format!("Cannot reassign immutable value"),
             ));
         }
 

--- a/brain-grammar/src/grammar/value/complex/mod.rs
+++ b/brain-grammar/src/grammar/value/complex/mod.rs
@@ -6,12 +6,14 @@ use self::enumdefinition::EnumDefinition;
 use self::function::Function;
 use self::map::Map;
 use self::r#enum::Enum;
+use self::tuple::Tuple;
 
 pub mod collection;
 pub mod r#enum;
 pub mod enumdefinition;
 pub mod function;
 pub mod map;
+pub mod tuple;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub enum ComplexValue {
@@ -20,6 +22,7 @@ pub enum ComplexValue {
     Function(Function),
     Enum(Enum),
     EnumDefinition(EnumDefinition),
+    Tuple(Tuple),
 }
 
 impl Display for ComplexValue {
@@ -30,6 +33,7 @@ impl Display for ComplexValue {
             ComplexValue::Function(function) => write!(f, "{}", function),
             ComplexValue::Enum(r#enum) => write!(f, "{}", r#enum),
             ComplexValue::EnumDefinition(enum_definition) => write!(f, "{}", enum_definition),
+            ComplexValue::Tuple(tuple) => write!(f, "{}", tuple),
         }
     }
 }
@@ -52,11 +56,13 @@ mod tests {
             "test".to_string(),
             vec!["one".to_string(), "two".to_string()],
         );
+        let tuple = Tuple::new(vec![]);
 
         assert_eq!(format!("{map}"), "{}");
         assert_eq!(format!("{collection}"), "[]");
         assert_eq!(format!("{function}"), "[function]");
         assert_eq!(format!("{enum}"), "test::one");
         assert_eq!(format!("{enum_definition}"), "enum test { one, two }");
+        assert_eq!(format!("{tuple}"), "()");
     }
 }

--- a/brain-grammar/src/grammar/value/complex/tuple.rs
+++ b/brain-grammar/src/grammar/value/complex/tuple.rs
@@ -1,0 +1,44 @@
+use crate::grammar::value::Value;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
+pub struct Tuple {
+    pub values: Vec<Value>,
+}
+
+impl Tuple {
+    pub fn new(values: Vec<Value>) -> Self {
+        Self { values }
+    }
+}
+
+impl std::fmt::Display for Tuple {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut s = String::new();
+
+        s.push('(');
+
+        for (i, value) in self.values.iter().enumerate() {
+            s.push_str(&format!("{}", value));
+
+            if i < self.values.len() - 1 {
+                s.push_str(", ");
+            }
+        }
+
+        s.push(')');
+
+        write!(f, "{}", s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tuple() {
+        let tuple = Tuple::new(vec![Value::new_number(1), Value::new_number(2)]);
+
+        assert_eq!(format!("{}", tuple), "(1, 2)");
+    }
+}

--- a/brain-grammar/src/grammar/value/mod.rs
+++ b/brain-grammar/src/grammar/value/mod.rs
@@ -12,6 +12,7 @@ use self::complex::enumdefinition::EnumDefinition;
 use self::complex::function::Function;
 use self::complex::map::Map;
 use self::complex::r#enum::Enum;
+use self::complex::tuple::Tuple;
 
 use super::statements::Statement;
 use super::token::BrainToken;
@@ -63,6 +64,10 @@ impl Value {
         Value::Complex(ComplexValue::EnumDefinition(EnumDefinition::new(
             name, variants,
         )))
+    }
+
+    pub fn new_tuple(tuple: Vec<Value>) -> Self {
+        Value::Complex(ComplexValue::Tuple(Tuple::new(tuple)))
     }
 }
 

--- a/brain-grammar/src/lib.rs
+++ b/brain-grammar/src/lib.rs
@@ -4,6 +4,7 @@ use self::grammar::{context::Context, output::Output, token::BrainToken, Nodes, 
 
 pub mod grammar;
 
+#[derive(Debug, Clone, PartialEq)]
 pub struct Program {
     pub stream: TokenStream<BrainToken>,
     pub context: Context,
@@ -17,9 +18,9 @@ impl Program {
         }
 
         Program {
-            stream: stream,
+            stream,
+            verbose,
             context: Context::new(),
-            verbose: verbose,
         }
     }
 

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -361,4 +361,55 @@ mod tests {
             &Value::new_boolean(true)
         );
     }
+
+    #[test]
+    fn tuple() {
+        let source = "let tuple = (1, 2, 3)".to_string();
+        let result = run(source);
+
+        let context = &result.unwrap().context;
+
+        assert_eq!(
+            context.symbols.get("tuple").unwrap(),
+            &Value::new_tuple(vec![
+                Value::new_number(1),
+                Value::new_number(2),
+                Value::new_number(3)
+            ])
+        );
+    }
+
+    #[test]
+    fn tuple_with_index_accessor() {
+        let source = "let tuple = (1, 2, 3); let x = tuple[0]".to_string();
+        let result = run(source);
+
+        let context = &result.unwrap().context;
+
+        assert_eq!(context.symbols.get("x").unwrap(), &Value::new_number(1));
+    }
+
+    #[test]
+    fn tuple_with_index_accessor_with_index_accessor() {
+        let source =
+            "let collection_of_tuples = [(1, 2, 3), (4, 5, 6)]; let x = collection_of_tuples[0][0]"
+                .to_string();
+        let result = run(source);
+
+        let context = &result.unwrap().context;
+
+        assert_eq!(context.symbols.get("x").unwrap(), &Value::new_number(1));
+    }
+
+    #[test]
+    // this should error as tuples are immutable
+    fn reassign_tuple() {
+        let source = "let tuple = (1, 2, 3); tuple = (4, 5, 6)".to_string();
+        let result = run(source);
+
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Cannot reassign immutable value"));
+    }
 }


### PR DESCRIPTION
tuples are an immutable collection of values that can be referenced with index accessors

```rust
let tuple = (1, 2);
print(tuple[0])
```

will output 1.

trying to re-assign a tuple will result in an error. tuples are explicitly immutable

```rust
let tuple = (1, 2);
tuple = (1, 2, 3);
```

will result in an error - `[ImmutableValue] - Cannot reassign immutable value`.

in the future, we should consider making all values immutable by default and adding a pattern to make them mutable

```rust
let mut number = 1;
number = 2;

let immutable = 1
immutable = 2
```

would throw an error in the second instance, indicating `immutable` is not declared as mutable.

tuples would still be immutable by default, though. 